### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ of [selenoid](https://github.com/aerokube/selenoid) on small go backend.
 
 We distribute UI as a lightweight [Docker](http://docker.com/) container. To run it type:
 ```
-$ docker run -d --name selenoid-ui --net host aerokube/selenoid-ui:1.0.0
+$ docker run -d --name selenoid-ui --net host aerokube/selenoid-ui
 ```
 Then access the UI on port 8080:
 ```


### PR DESCRIPTION
When I was trying to run docker run -d --name selenoid-ui --net host aerokube/selenoid-ui:1.0.0
I got the following error:
Unable to find image 'aerokube/selenoid-ui:1.0.0' locally
docker: Error response from daemon: manifest for aerokube/selenoid-ui:1.0.0 not found.
See 'docker run --help'.

Without version it works perfectly.