### PR TITLE
mitigation for #157

### DIFF
--- a/ui/src/components/Videos/index.js
+++ b/ui/src/components/Videos/index.js
@@ -7,7 +7,7 @@ import "./style.scss";
 const Videos = (props) => {
     const {videos} = props;
     const list = Object.keys(videos);
-
+    const preloadVal = list.length > 100 ? "none" : "auto";
     return (
 
         <div className="videos">
@@ -27,11 +27,12 @@ const Videos = (props) => {
                             >
 
                                 <div className="videos-container">
+
                                     <div className="video-cap video-cap__name"
                                          title={videos[video]}>
                                         {videos[video]}
                                     </div>
-                                    <video controls preload="auto">
+                                    <video controls preload={preloadVal}>
                                         <source src={src} type="video/mp4" />
                                     </video>
                                 </div>


### PR DESCRIPTION
i was not able to reproduce locally, i used ~500+ videos but i noticed chrome used more memory and cpu.  so the preload property in this pr is conditional > 100 videos is set to none.
fixes #157