### PR TITLE
Clean up capabilities of non-W3C capability names

### DIFF
--- a/ui/src/containers/Capabilities/index.js
+++ b/ui/src/containers/Capabilities/index.js
@@ -25,13 +25,17 @@ enableVideo: false
 `,
         curl: `curl -X POST 'http://127.0.0.1:4444/wd/hub/session' -d '{ 
             "desiredCapabilities":{
-                "browserName":"${browser}", 
+                "browserName": "${browser}", 
                 "version": "${version}", 
-                "platform":"ANY",
+                "platform": "ANY",
                 "enableVNC": true,
                 "name": "this.test.is.launched.by.curl",
                 "sessionTimeout": "120s"
-            }
+            },
+	    "capabilities": {
+		"browserName": "${browser}",
+		"browserVersion": "${version}"
+	    }
         }'
 `,
         java: `DesiredCapabilities capabilities = new DesiredCapabilities();
@@ -185,15 +189,8 @@ const Launch = ({ browser: { name, version }, history }) => {
                                 name: "Manual session",
                             },
                             capabilities: {
-                                alwaysMatch: {
-                                    browserName: `${name}`,
-                                    browserVersion: `${version}`,
-                                    "selenoid:options": {
-                                        enableVNC: true,
-                                        sessionTimeout: "60m",
-                                        labels: { manual: "true" },
-                                    },
-                                },
+                                browserName: `${name}`,
+                                browserVersion: `${version}`,
                             },
                         },
                     }).pipe(


### PR DESCRIPTION
This change will allow the manual start for all major browsers including IE 11 and Edge 18.

Ideally you will keep the `alwaysMatch`, but then Edge will shock on it. 

**Note:** I also update the `CURL` sample code to display the change

![selenoid-ui-manual-sessions](https://user-images.githubusercontent.com/9518604/68040044-d383a680-fca3-11e9-83c9-70c771c08bd8.png)