### PR TITLE
Fixes issue where "." in video name would cause premature truncation

### DIFF
--- a/ui/src/components/Videos/index.js
+++ b/ui/src/components/Videos/index.js
@@ -15,7 +15,7 @@ const Videos = ({ videos = [], query = "" }) => {
                 {filtered.length &&
                     filtered.map(fname => {
                         const src = `/video/${fname}`;
-                        const session = fname.split(".")[0];
+                        const session = fname.match(/.*(?=\.)/)[0];
 
                         return (
                             <CSSTransition key={fname} timeout={500} classNames="video__container_state" unmountOnExit>


### PR DESCRIPTION
"." in video name would cause video title's to be truncated too early. Only the stuff after the last dot should represent the video extension and be filtered out.