### PR TITLE
Added CA-Certs to scratch container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
+FROM golang:alpine as build
+# Install CA-Certs
+RUN apk --no-cache add ca-certificates
+
 FROM scratch
 MAINTAINER Kirill Merkushev <lanwen@yandex.ru>
 
 COPY selenoid-ui /
 COPY health-check /
 COPY licenses /
+
+# Copy CA-Certs from build to scratch image
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 HEALTHCHECK --interval=30s --timeout=2s --start-period=2s --retries=2 CMD [ "/health-check" ]
 EXPOSE 8080


### PR DESCRIPTION
Hey,
it seems that https urls are not supported in docker deployments:
```
2022/11/24 16:57:08 [ERROR] [Can't get status: Get "https://***/status": x509: certificate signed by unknown authority]
2022/11/24 16:57:08 Removed client. 1 registered clients
2022/11/24 16:57:13 [ERROR] [Can't get status: Get "https://***/status": x509: certificate signed by unknown authority]
```
Adding CA-Certs to docker fixes this.
