### PR TITLE
Fix shortened Session Id display

### DIFF
--- a/ui/src/components/Sessions/index.js
+++ b/ui/src/components/Sessions/index.js
@@ -68,7 +68,7 @@ const Session = ({ id, session: { quota, caps } }) => {
             <SessionId>
                 <span className="quota">{quota}</span> /{" "}
                 <Link to={deleting ? `#` : `/sessions/${id}`} className="id">
-                    {id.substring(0, 8)}
+                    {id.substring(0, id.indexOf('-') === -1 ? 8 : id.indexOf('-')}
                 </Link>
             </SessionId>
             <Link className="identity" to={deleting ? `#` : `/sessions/${id}`}>

--- a/ui/src/components/Sessions/index.js
+++ b/ui/src/components/Sessions/index.js
@@ -68,7 +68,7 @@ const Session = ({ id, session: { quota, caps } }) => {
             <SessionId>
                 <span className="quota">{quota}</span> /{" "}
                 <Link to={deleting ? `#` : `/sessions/${id}`} className="id">
-                    {id.substring(0, id.indexOf('-') === -1 ? 8 : id.indexOf('-')}
+                    {id.substring(0, id.indexOf('-') === -1 ? 8 : id.indexOf('-'))}
                 </Link>
             </SessionId>
             <Link className="identity" to={deleting ? `#` : `/sessions/${id}`}>

--- a/ui/src/components/Sessions/index.js
+++ b/ui/src/components/Sessions/index.js
@@ -68,7 +68,7 @@ const Session = ({ id, session: { quota, caps } }) => {
             <SessionId>
                 <span className="quota">{quota}</span> /{" "}
                 <Link to={deleting ? `#` : `/sessions/${id}`} className="id">
-                    {id.substring(0, id.indexOf("-"))}
+                    {id.substring(0, 8)}
                 </Link>
             </SessionId>
             <Link className="identity" to={deleting ? `#` : `/sessions/${id}`}>


### PR DESCRIPTION
## Changes

Fixed the displaying of the short version of the Session ID on the Session's container:

### Before
<img width="734" alt="image" src="https://user-images.githubusercontent.com/42677987/206201328-fea00664-ca9c-4011-bfc0-cdd76ca3b69c.png">

### After
<img width="791" alt="image" src="https://user-images.githubusercontent.com/42677987/206202090-06d50f0e-1e52-4375-aa38-57aa8729d27a.png">

